### PR TITLE
Lowercase entity names in intent matches for backwards-compat.

### DIFF
--- a/padacioso/__init__.py
+++ b/padacioso/__init__.py
@@ -32,12 +32,14 @@ class IntentContainer:
             del self.intent_samples[name]
 
     def add_entity(self, name, lines):
+        name = name.lower()
         expanded = []
         for l in lines:
             expanded += expand_parentheses(l)
         self.entity_samples[name] = expanded
 
     def remove_entity(self, name):
+        name = name.lower()
         if name in self.entity_samples:
             del self.entity_samples[name]
 
@@ -52,7 +54,10 @@ class IntentContainer:
 
                 entities = simplematch.match(r, query, case_sensitive=True)
                 if entities is not None:
-                    for k, v in entities.items():
+                    for k in set(entities.keys()):
+                        v = entities.pop(k)
+                        k = k.lower()
+                        entities[k] = v
                         if k not in self.entity_samples:
                             # penalize unregistered entities
                             penalty += 0.1
@@ -68,7 +73,10 @@ class IntentContainer:
                 if entities is not None:
                     # penalize case mismatch
                     penalty += 0.05
-                    for k, v in entities.items():
+                    for k in set(entities.keys()):
+                        v = entities.pop(k)
+                        k = k.lower()
+                        entities[k] = v
                         if k not in self.entity_samples:
                             # penalize unregistered entities
                             penalty += 0.1
@@ -85,6 +93,10 @@ class IntentContainer:
                     for f in self._get_fuzzed(r):
                         entities = simplematch.match(f, query, case_sensitive=False)
                         if entities is not None:
+                            for k in set(entities.keys()):
+                                v = entities.pop(k)
+                                k = k.lower()
+                                entities[k] = v
                             yield {"entities": entities or {},
                                    "conf": 1 - penalty,
                                    "name": intent_name}

--- a/test/test_padacioso.py
+++ b/test/test_padacioso.py
@@ -70,7 +70,7 @@ class TestIntentContainer(unittest.TestCase):
 
     def test_multiple_entities(self):
         container = IntentContainer()
-        container.add_intent('test3', ['I see {thing} (in|on) {place}'])
+        container.add_intent('test3', ['I see {Thing} (in|on) {place}'])
         self.assertEqual(
             container.calc_intent('I see a bin in there'),
             {'conf': 0.8,  # unregistered entity * 2


### PR DESCRIPTION
Add unit test case for entity name normalization
Closes #3