### PR TITLE
Optimization and Confidence Adjustments

### DIFF
--- a/padacioso/__init__.py
+++ b/padacioso/__init__.py
@@ -62,7 +62,7 @@ class IntentContainer:
                     for k, v in entities.items():
                         if k not in self.entity_samples:
                             # penalize unregistered entities
-                            penalty += 0.05
+                            penalty += 0.04
                         elif str(v) not in self.entity_samples[k]:
                             # penalize parsed entity value not in samples
                             penalty += 0.1

--- a/padacioso/__init__.py
+++ b/padacioso/__init__.py
@@ -58,10 +58,10 @@ class IntentContainer:
                     for k, v in entities.items():
                         if k not in self.entity_samples:
                             # penalize unregistered entities
-                            penalty += 0.1
-                        elif str(v) not in self.entity_samples[k]:
-                            # penalize unknown samples
                             penalty += 0.05
+                        elif str(v) not in self.entity_samples[k]:
+                            # penalize parsed entity value not in samples
+                            penalty += 0.1
                     yield {"entities": entities or {},
                            "conf": 1 - penalty,
                            "name": intent_name}
@@ -74,10 +74,10 @@ class IntentContainer:
                     for k, v in entities.items():
                         if k not in self.entity_samples:
                             # penalize unregistered entities
-                            penalty += 0.1
-                        elif str(v) not in self.entity_samples[k]:
-                            # penalize unknown samples
                             penalty += 0.05
+                        elif str(v) not in self.entity_samples[k]:
+                            # penalize parsed entity value not in samples
+                            penalty += 0.1
                     yield {"entities": entities or {},
                            "conf": 1 - penalty,
                            "name": intent_name}
@@ -86,7 +86,8 @@ class IntentContainer:
                 if self.fuzz:
                     penalty += 0.25
                     for f in self._get_fuzzed(r):
-                        entities = simplematch.match(f, query, case_sensitive=False)
+                        entities = simplematch.match(f, query,
+                                                     case_sensitive=False)
                         if entities is not None:
                             yield {"entities": entities or {},
                                    "conf": 1 - penalty,
@@ -99,7 +100,6 @@ class IntentContainer:
             key=lambda x: x["conf"],
             default={'name': None, 'entities': {}}
         )
-        LOG.debug(match)
         for entity in set(match['entities'].keys()):
             entities = match['entities'].pop(entity)
             match['entities'][entity.lower()] = entities

--- a/padacioso/__init__.py
+++ b/padacioso/__init__.py
@@ -1,9 +1,9 @@
 import simplematch
 import logging
 
-import time
 from padacioso.bracket_expansion import expand_parentheses, clean_braces
 LOG = logging.getLogger('padacioso')
+
 
 class IntentContainer:
     def __init__(self, fuzz=False):
@@ -99,6 +99,7 @@ class IntentContainer:
             key=lambda x: x["conf"],
             default={'name': None, 'entities': {}}
         )
+        LOG.debug(match)
         for entity in set(match['entities'].keys()):
             entities = match['entities'].pop(entity)
             match['entities'][entity.lower()] = entities

--- a/padacioso/__init__.py
+++ b/padacioso/__init__.py
@@ -1,8 +1,12 @@
 import simplematch
-import logging
 
 from padacioso.bracket_expansion import expand_parentheses, clean_braces
-LOG = logging.getLogger('padacioso')
+
+try:
+    from ovos_utils.log import LOG
+except ImportError:
+    import logging
+    LOG = logging.getLogger('padacioso')
 
 
 class IntentContainer:
@@ -103,4 +107,5 @@ class IntentContainer:
         for entity in set(match['entities'].keys()):
             entities = match['entities'].pop(entity)
             match['entities'][entity.lower()] = entities
+        LOG.debug(match)
         return match

--- a/test/test_padacioso.py
+++ b/test/test_padacioso.py
@@ -49,15 +49,15 @@ class TestIntentContainer(unittest.TestCase):
         })
         self.assertEqual(container.calc_intent('buy beer'), {
             'name': 'buy', 'entities': {'item': 'beer'},
-            "conf": 0.95  # unseen entity example
+            "conf": 0.9  # unseen entity example
         })
         self.assertEqual(container.calc_intent('eat some bananas'), {
             'name': 'eat', 'entities': {'fruit': 'bananas'},
-            "conf": 0.9  # unregistered entity
+            "conf": 0.96  # unregistered entity
         })
         self.assertEqual(container.calc_intent("drive me to the store"), {
             'name': 'drive', 'entities': {'place': 'the store'},
-            'conf': 0.9
+            'conf': 0.96
         })
 
     def test_case(self):
@@ -73,7 +73,7 @@ class TestIntentContainer(unittest.TestCase):
         container.add_intent('test3', ['I see {Thing} (in|on) {place}'])
         self.assertEqual(
             container.calc_intent('I see a bin in there'),
-            {'conf': 0.8,  # unregistered entity * 2
+            {'conf': 0.92,  # unregistered entity * 2
              'entities': {'place': 'there', 'thing': 'a bin'},
              'name': 'test3'}
         )
@@ -91,17 +91,17 @@ class TestIntentContainer(unittest.TestCase):
         container.add_intent('test_int', ['* number {number:int}'])
         self.assertEqual(
             container.calc_intent('i want nuMBer 3'),
-            {'conf': 0.7,  # wildcard + unregistered entity + bad case
+            {'conf': 0.75,  # wildcard + unregistered entity + bad case
              'entities': {'number': 3}, 'name': 'test_int'})
         self.assertEqual(
             container.calc_intent('i want number 3'),
-            {'conf': 0.75,  # wildcard + unregistered entity
+            {'conf': 0.81,  # wildcard + unregistered entity
              'entities': {'number': 3}, 'name': 'test_int'})
 
         container.add_entity("number", ["1", "2", "3", "4", "5"])
         self.assertEqual(
             container.calc_intent('i want number 10'),
-            {'conf': 0.8,  # wildcard + unseen entity example
+            {'conf': 0.75,  # wildcard + unseen entity example
              'entities': {'number': 10}, 'name': 'test_int'})
         self.assertEqual(
             container.calc_intent('i want number 3'),
@@ -115,7 +115,7 @@ class TestIntentContainer(unittest.TestCase):
         container.add_intent('test_float', ['* float {number:float}'])
         self.assertEqual(
             container.calc_intent('i want float 3'),
-            {'conf': 0.8,   # wildcard + unseen entity example
+            {'conf': 0.75,   # wildcard + unseen entity example
              'entities': {'number': 3.0}, 'name': 'test_float'})
 
     def test_no_fuzz(self):


### PR DESCRIPTION
Moves normalization to only run on matched intent instead of all yielded results
Updates confidence levels for backwards-compat (specifically testing the neon date-time skill)


To justify some of the confidence changes:

- An named entity with no examples should be penalized less than an entity with examples where none of the examples are present
- An intent with a named entity should be able to return a high-confidence match