### PR TITLE
Optimize intent matching

### DIFF
--- a/padacioso/__init__.py
+++ b/padacioso/__init__.py
@@ -13,7 +13,7 @@ except ImportError:
 class IntentContainer:
     def __init__(self, fuzz=False):
         self.intent_samples, self.entity_samples = {}, {}
-        self.intents, self.entities = {}, {}
+        # self.intents, self.entities = {}, {}
         self.fuzz = fuzz
         self._cased_matchers = dict()
         self._uncased_matchers = dict()
@@ -42,6 +42,9 @@ class IntentContainer:
         @param name: name of intent to add
         @param lines: list of intent regexes
         """
+        if name in self.intent_samples:
+            raise RuntimeError(f"Attempted to re-register existing intent: "
+                               f"{name}")
         expanded = []
         for l in lines:
             expanded += expand_parentheses(clean_braces(l))
@@ -73,6 +76,9 @@ class IntentContainer:
         @param name: name of entity to add
         @param lines: list of entity examples
         """
+        if name in self.entity_samples:
+            raise RuntimeError(f"Attempted to re-register existing entity: "
+                               f"{name}")
         name = name.lower()
         expanded = []
         for l in lines:

--- a/padacioso/__init__.py
+++ b/padacioso/__init__.py
@@ -46,6 +46,7 @@ class IntentContainer:
         for l in lines:
             expanded += expand_parentheses(clean_braces(l))
         regexes = list(set(expanded))
+        regexes.sort(key=len, reverse=True)
         self.intent_samples[name] = regexes
         for r in regexes:
             self._cased_matchers[r] = \
@@ -94,7 +95,6 @@ class IntentContainer:
         @return: yields dict intent matches
         """
         for intent_name, regexes in self.intent_samples.items():
-            regexes = sorted(regexes, key=len, reverse=True)
             for r in regexes:
                 penalty = 0
                 if "*" in r:

--- a/test/test_padacioso.py
+++ b/test/test_padacioso.py
@@ -167,3 +167,39 @@ class TestIntentContainer(unittest.TestCase):
         self.assertEqual(intent["name"], "test2")
         self.assertEqual(intent["entities"], {'thing': 'Mycroft'})
 
+    def test_add_remove_intent(self):
+        container = IntentContainer()
+        # Add intent valid
+        container.add_intent("hello", ["hi", "hello", "howdy",
+                                       "how (are you|do you do)"])
+        self.assertEqual(len(container.intent_samples['hello']), 5)
+        self.assertEqual(len(container._cased_matchers), 5)
+        self.assertEqual(len(container._cased_matchers),
+                         len(container._uncased_matchers))
+        # Add intent already defined
+        with self.assertRaises(RuntimeError):
+            container.add_intent("hello", ["invalid"])
+        # Add second intent
+        container.add_intent("test", ["test(ing|)"])
+        self.assertEqual(len(container.intent_samples['test']), 2)
+        self.assertEqual(len(container._cased_matchers),
+                         len(container._uncased_matchers))
+        # Remove intent
+        container.remove_intent("test")
+        self.assertNotIn("test", container.intent_samples)
+        self.assertEqual(len(container.intent_samples['hello']), 5)
+        self.assertEqual(len(container._cased_matchers), 5)
+        self.assertEqual(len(container._cased_matchers),
+                         len(container._uncased_matchers))
+
+    def test_add_remove_entity(self):
+        container = IntentContainer()
+        # Add entity valid
+        container.add_entity("entity", ["test(ing|)", "another test"])
+        self.assertEqual(len(container.entity_samples["entity"]), 3)
+        # Add entity already defined
+        with self.assertRaises(RuntimeError):
+            container.add_entity("entity", ["invalid"])
+        # Remove entity
+        container.remove_entity("entity")
+        self.assertNotIn("entity", container.entity_samples.keys())


### PR DESCRIPTION
Refactor to reduce object init at runtime for faster intent matching
- regex sorting is moved to happen at intent registration instead of runtime
- `Matcher` objects are initialized at registration and destroyed on removal instead of created at runtime
- Removes unused `intents` and `entities` properties
- *Now raises an exception when registering an existing entity/intent instead or overriding the previous*