### PR TITLE
Adds support for Padatious `:0` syntax with unit tests

### DIFF
--- a/padacioso/bracket_expansion.py
+++ b/padacioso/bracket_expansion.py
@@ -195,3 +195,24 @@ def clean_braces(example: str) -> str:
     """
     clean = example.replace('{{', '{').replace('}}', '}')
     return clean
+
+
+def translate_padatious(example: str) -> str:
+    """
+    Translate Padatious `:0` syntax to standard regex
+    @param example: input intent example
+    @return: parsed intent example with Padatious syntax replaced with regex
+    """
+    if ':0' not in example:
+        return example
+    tokens = example.split()
+    i = 0
+    for idx, token in enumerate(tokens):
+        if token == ":0":
+            tokens[idx] = '{' + f'word{i}:word' + '}'
+            i += 1
+    return " ".join(tokens)
+
+
+def normalize_example(example: str) -> str:
+    return clean_braces(translate_padatious(example))

--- a/test/test_padacioso.py
+++ b/test/test_padacioso.py
@@ -203,3 +203,29 @@ class TestIntentContainer(unittest.TestCase):
         # Remove entity
         container.remove_entity("entity")
         self.assertNotIn("entity", container.entity_samples.keys())
+
+    def test_translate_padatious(self):
+        from padacioso.bracket_expansion import translate_padatious
+        intent = ":0 :0 what time is it"
+        self.assertEqual(translate_padatious(intent),
+                         "{word0:word} {word1:word} what time is it")
+
+    def test_add_padatious_wildcard_intent(self):
+        container = IntentContainer()
+        container.add_intent("test_single_wildcard", [":0 what time is it"])
+        match = container.calc_intent("neon what time is it")
+        self.assertEqual(match['name'], 'test_single_wildcard')
+        self.assertEqual(match['entities']['word0'], 'neon')
+
+        match = container.calc_intent("neon neon what time is it")
+        self.assertIsNone(match['name'])
+
+        container.add_intent("test_double_wildcard", [":0 :0 how are you"])
+        match = container.calc_intent("neon how are you")
+        self.assertIsNone(match['name'])
+
+        match = container.calc_intent("neon neon how are you")
+        self.assertEqual(match['name'], 'test_double_wildcard')
+        self.assertEqual(match['entities']['word0'], 'neon')
+        self.assertEqual(match['entities']['word1'], 'neon')
+


### PR DESCRIPTION
Note that this does create an edge case if an existing intent specifies `:0` and `{word0}`, but this seems unlikely.

Closes #11