### PR TITLE
fix(deps): allow ovos-bus-client 2.x (widen cap to <3.0.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ extras = [
 test = [
     "ovos-plugin-manager>=0.5.0,<3.0.0",
     "ovos-utils>=0.3.5,<1.0.0",
-    "ovos-bus-client>=0.0.8,<2.0.0",
+    "ovos-bus-client>=0.0.8,<3.0.0",
     "langcodes",
 ]
 


### PR DESCRIPTION
ovos-bus-client 2.x dropped only the bundled hivemind protocol + messagebus solver (#207) — no API break (#215). Widen `<2.0.0`→`<3.0.0` (1.x stays default). Stack-wide migration for HiveMind 2.x adoption.