### PR TITLE
feat: consume OVOS-INTENT-4 template registration (alongside legacy)

### DIFF
--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'padacioso/**'
       - 'test/test_ovoscope_e2e.py'
+      - 'test/end2end/**'
       - '.github/workflows/ovoscope.yml'
   workflow_dispatch:
 
@@ -14,7 +15,7 @@ jobs:
     uses: OpenVoiceOS/gh-automations/.github/workflows/ovoscope.yml@dev
     with:
       install_extras: "test"
-      test_path: "test/test_ovoscope_e2e.py"
+      test_path: "test/test_ovoscope_e2e.py test/end2end/"
       # padacioso is always available via ovos-workshop, but install it
       # explicitly here so the engine under test is the local checkout
       # (not whatever ovos-workshop ships).

--- a/padacioso/opm.py
+++ b/padacioso/opm.py
@@ -457,6 +457,12 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
         blacklisted_skills = frozenset(sess.blacklisted_skills or [])
 
         intent_container = self.containers.get(lang)
+        # Invalidate the burst cache once per match call: registrations,
+        # deregistrations, disables and detaches all mutate the container
+        # between calls, and a stale cache entry would keep a removed intent
+        # matching. The intra-call burst (multiple ASR hypotheses below) still
+        # benefits from the cache after this clear.
+        _calc_padacioso_intent.cache_clear()
         intents = [_calc_padacioso_intent(utt, intent_container,
                                           blacklisted_intents, blacklisted_skills)
                    for utt in utterances]
@@ -492,7 +498,9 @@ def _calc_padacioso_intent(utt: str,
         Optional[PadaciosoIntent]:
     """
     Try to match an utterance to an intent in an intent_container
-    @param args: tuple of (utterance, IntentContainer)
+
+    The session blacklists are passed as hashable frozensets so this stays
+    ``lru_cache``-able (Session is unhashable under ovos-bus-client>=2.4.0a1).
     @return: matched PadaciosoIntent
     """
     try:

--- a/padacioso/opm.py
+++ b/padacioso/opm.py
@@ -9,7 +9,7 @@ from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager, Session
 from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
-from ovos_spec_tools import closest_lang, standardize_lang
+from ovos_spec_tools import closest_lang, standardize_lang, SpecMessage
 from ovos_utils import flatten_list
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG, log_deprecation
@@ -69,15 +69,45 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
             self.config.get("fuzz"), n_workers=self.workers)
             for lang in langs}
 
+        # legacy padatious registration topics (back-compat)
         self.bus.on('padatious:register_intent', self.register_intent)
         self.bus.on('padatious:register_entity', self.register_entity)
         self.bus.on('detach_intent', self.handle_detach_intent)
         self.bus.on('detach_skill', self.handle_detach_skill)
 
+        # OVOS-INTENT-4 registration topics. padacioso is a TEMPLATE engine,
+        # so it consumes the template registration topic (§6) and ignores
+        # ovos.intent.register.keyword (§11 conformance). Entity (§7) and
+        # deregister/enable/disable (§8) are consumed too.
+        self.bus.on(SpecMessage.INTENT_REGISTER_TEMPLATE.value, self.handle_register_template)
+        self.bus.on(SpecMessage.ENTITY_REGISTER.value, self.handle_register_entity)
+        self.bus.on(SpecMessage.INTENT_DEREGISTER.value, self.handle_deregister_intent)
+        self.bus.on(SpecMessage.ENTITY_DEREGISTER.value, self.handle_deregister_entity)
+        self.bus.on(SpecMessage.SKILL_DEREGISTER.value, self.handle_deregister_skill)
+        self.bus.on(SpecMessage.INTENT_ENABLE.value, self.handle_enable_intent)
+        self.bus.on(SpecMessage.INTENT_DISABLE.value, self.handle_disable_intent)
+
         self.registered_intents = []
         self.registered_entities = []
+        # OVOS-INTENT-4 §8.5 enable/disable: keep the expanded template samples
+        # keyed by (lang, internal_name) so a disabled intent can be re-armed
+        # without losing its definition.
+        self._template_samples = {}
         self.max_words = 50  # if an utterance contains more words than this, don't attempt to match
         LOG.debug('Loaded Padacioso intent parser.')
+
+    @staticmethod
+    def _internal_name(skill_id: str, intent_name: str) -> str:
+        """Compose the engine-internal namespaced intent name.
+
+        padacioso stores intents under ``<skill_id>:<intent_name>`` (the
+        match result's skill_id is derived by splitting on ``:``). OVOS-INTENT-4
+        carries ``skill_id`` and ``intent_name`` as distinct fields (§3.2), so
+        recompose the legacy form here.
+        """
+        if intent_name and skill_id and not intent_name.startswith(f"{skill_id}:"):
+            return f"{skill_id}:{intent_name}"
+        return intent_name or skill_id
 
     @property
     def padacioso_config(self) -> Dict:
@@ -243,6 +273,160 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
             self._register_object(message, 'entity',
                                   self.containers[lang].add_entity)
 
+    # ------------------------------------------------------------------
+    # OVOS-INTENT-4 bus handlers (consumed alongside the legacy topics)
+    # ------------------------------------------------------------------
+    def _warn_malformed(self, topic: str, data: Dict, reason: str):
+        """§5.3 / §6.3 / §7.2 — log a malformed registration at WARN.
+
+        fire-and-forget means this log is the producer's only debugging signal.
+        """
+        LOG.warning(
+            f"rejecting malformed registration on {topic}: "
+            f"skill_id={data.get('skill_id')!r} "
+            f"intent_name={data.get('intent_name') or data.get('entity_name')!r} "
+            f"lang={data.get('lang')!r} reason={reason}")
+
+    def handle_register_template(self, message: Message):
+        """OVOS-INTENT-4 §6 — register a template intent.
+
+        Maps the spec payload (``skill_id`` + ``intent_name`` + ``samples`` +
+        optional ``blacklist`` + ``lang``) onto the engine's namespaced
+        ``add_intent`` call, reusing the legacy registration internals.
+        """
+        topic = SpecMessage.INTENT_REGISTER_TEMPLATE.value
+        data = message.data
+        skill_id = data.get("skill_id")
+        intent_name = data.get("intent_name")
+        samples = data.get("samples")
+        if not samples:  # §6.3 malformed
+            self._warn_malformed(topic, data, "missing or empty 'samples'")
+            return
+        if not intent_name or not skill_id:  # §3.2 identity required
+            self._warn_malformed(topic, data, "missing 'skill_id' or 'intent_name'")
+            return
+
+        lang = standardize_lang(data.get("lang", self.lang))
+        if lang not in self.containers:
+            LOG.debug(f"ignoring template registration for unconfigured lang: {lang}")
+            return
+
+        name = self._internal_name(skill_id, intent_name)
+        # §8.1 replacement is implicit: a re-registration replaces the prior entry
+        self.__detach_intent(name)
+        self.registered_intents.append(name)
+        self._template_samples[(lang, name)] = list(samples)
+        try:
+            self.containers[lang].add_intent(name, samples)
+        except RuntimeError:
+            if name not in self.containers[lang].intent_samples:
+                raise
+
+        blacklist = data.get("blacklist")
+        if blacklist:  # §6.1 suppression phrases
+            self.containers[lang].exclude_keywords(name, list(blacklist))
+
+    def handle_register_entity(self, message: Message):
+        """OVOS-INTENT-4 §7 — register an entity value-set hint."""
+        topic = SpecMessage.ENTITY_REGISTER.value
+        data = message.data
+        skill_id = data.get("skill_id")
+        entity_name = data.get("entity_name")
+        samples = data.get("samples")
+        if not samples:  # §7.2 malformed
+            self._warn_malformed(topic, data, "missing or empty 'samples'")
+            return
+        if not entity_name or not skill_id:
+            self._warn_malformed(topic, data, "missing 'skill_id' or 'entity_name'")
+            return
+
+        lang = standardize_lang(data.get("lang", self.lang))
+        if lang not in self.containers:
+            LOG.debug(f"ignoring entity registration for unconfigured lang: {lang}")
+            return
+
+        name = self._internal_name(skill_id, entity_name)
+        # §8.1 replacement is implicit
+        self.__detach_entity(name, lang)
+        self.registered_entities = [
+            e for e in self.registered_entities
+            if not (e.get("name") == name and e.get("lang") == lang)]
+        self.registered_entities.append({"name": name, "lang": lang})
+        self.containers[lang].add_entity(name, samples)
+
+    def _intent_langs(self, message: Message) -> List[str]:
+        """Resolve which container langs a deregister/enable/disable targets.
+
+        §8.2 — when ``lang`` is omitted every registered language is affected.
+        """
+        lang = message.data.get("lang")
+        if lang:
+            lang = standardize_lang(lang)
+            return [lang] if lang in self.containers else []
+        return list(self.containers.keys())
+
+    def handle_deregister_intent(self, message: Message):
+        """OVOS-INTENT-4 §8.2 — remove one intent (all langs if lang omitted)."""
+        skill_id = message.data.get("skill_id")
+        intent_name = message.data.get("intent_name")
+        name = self._internal_name(skill_id, intent_name)
+        self.__detach_intent(name)
+        for lang in self._intent_langs(message):
+            self._template_samples.pop((lang, name), None)
+
+    def handle_deregister_entity(self, message: Message):
+        """OVOS-INTENT-4 §8.3 — remove one entity (all langs if lang omitted)."""
+        skill_id = message.data.get("skill_id")
+        entity_name = message.data.get("entity_name")
+        name = self._internal_name(skill_id, entity_name)
+        for lang in self._intent_langs(message):
+            self.__detach_entity(name, lang)
+        self.registered_entities = [
+            e for e in self.registered_entities if e.get("name") != name]
+
+    def handle_deregister_skill(self, message: Message):
+        """OVOS-INTENT-4 §8.4 — remove everything owned by a skill_id."""
+        skill_id = message.data.get("skill_id")
+        if not skill_id:
+            return
+        prefix = skill_id + ":"
+        for i in [i for i in self.registered_intents
+                  if i == skill_id or i.startswith(prefix)]:
+            self.__detach_intent(i)
+            for lang in self.containers:
+                self._template_samples.pop((lang, i), None)
+        for en in list(self.registered_entities):
+            if en["name"] == skill_id or en["name"].startswith(prefix):
+                self.__detach_entity(en["name"], en["lang"])
+        self.registered_entities = [
+            e for e in self.registered_entities
+            if not (e["name"] == skill_id or e["name"].startswith(prefix))]
+
+    def handle_disable_intent(self, message: Message):
+        """OVOS-INTENT-4 §8.5 — suppress an intent without losing its definition.
+
+        The container has no native disable, so the regexes are removed from
+        matching while the expanded samples are retained for re-arming (§8.5).
+        """
+        skill_id = message.data.get("skill_id")
+        intent_name = message.data.get("intent_name")
+        name = self._internal_name(skill_id, intent_name)
+        for lang in self._intent_langs(message):
+            if name in self.containers[lang].intent_samples:
+                self.containers[lang].remove_intent(name)
+
+    def handle_enable_intent(self, message: Message):
+        """OVOS-INTENT-4 §8.5 — re-arm a previously disabled intent."""
+        skill_id = message.data.get("skill_id")
+        intent_name = message.data.get("intent_name")
+        name = self._internal_name(skill_id, intent_name)
+        for lang in self._intent_langs(message):
+            if name in self.containers[lang].intent_samples:
+                continue  # already enabled, no-op
+            samples = self._template_samples.get((lang, name))
+            if samples:
+                self.containers[lang].add_intent(name, samples)
+
     def calc_intent(self, utterances: List[str], lang: str = None,
                     message: Optional[Message] = None) -> Optional[PadaciosoIntent]:
         """
@@ -291,6 +475,13 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
         self.bus.remove('padatious:register_entity', self.register_entity)
         self.bus.remove('detach_intent', self.handle_detach_intent)
         self.bus.remove('detach_skill', self.handle_detach_skill)
+        self.bus.remove(SpecMessage.INTENT_REGISTER_TEMPLATE.value, self.handle_register_template)
+        self.bus.remove(SpecMessage.ENTITY_REGISTER.value, self.handle_register_entity)
+        self.bus.remove(SpecMessage.INTENT_DEREGISTER.value, self.handle_deregister_intent)
+        self.bus.remove(SpecMessage.ENTITY_DEREGISTER.value, self.handle_deregister_entity)
+        self.bus.remove(SpecMessage.SKILL_DEREGISTER.value, self.handle_deregister_skill)
+        self.bus.remove(SpecMessage.INTENT_ENABLE.value, self.handle_enable_intent)
+        self.bus.remove(SpecMessage.INTENT_DISABLE.value, self.handle_disable_intent)
 
 
 @lru_cache(maxsize=128)  # covers burst of multiple ASR hypotheses without thrashing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,12 @@ extras = [
     "ovos-plugin-manager>=0.5.0,<3.0.0",
 ]
 test = [
-    # ovos-bus-client>=2.4.0a1 is only satisfiable with opm 2.x (prerelease);
+    # ovos-bus-client>=2.5.1a1 is only satisfiable with opm 2.x (prerelease);
     # the stable opm releases all cap ovos-bus-client<2.0.0. Pin the prerelease
     # floor so the resolver picks it without --pre.
     "ovos-plugin-manager>=2.3.0a1,<3.0.0",
     "ovos-utils>=0.3.5,<1.0.0",
-    "ovos-bus-client>=2.4.0a1,<3.0.0",
+    "ovos-bus-client>=2.5.1a1,<3.0.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "jarbasai", email = "jarbasai@mailfence.com" }]
 requires-python = ">=3.8"
 dependencies = [
     "simplematch",
-    "ovos-spec-tools>=0.0.1a2,<1.0.0",
+    "ovos-spec-tools>=0.10.0a1,<1.0.0",
     "ovos-utils>=0.3.5,<1.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "jarbasai", email = "jarbasai@mailfence.com" }]
 requires-python = ">=3.8"
 dependencies = [
     "simplematch",
-    "ovos-spec-tools>=0.11.0a1,<1.0.0",
+    "ovos-spec-tools>=0.16.1a2,<1.0.0",
     "ovos-utils>=0.3.5,<1.0.0",
 ]
 
@@ -23,7 +23,7 @@ extras = [
 test = [
     "ovos-plugin-manager>=0.5.0,<3.0.0",
     "ovos-utils>=0.3.5,<1.0.0",
-    "ovos-bus-client>=0.0.8,<3.0.0",
+    "ovos-bus-client>=2.4.0a1,<3.0.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "jarbasai", email = "jarbasai@mailfence.com" }]
 requires-python = ">=3.8"
 dependencies = [
     "simplematch",
-    "ovos-spec-tools>=0.10.0a1,<1.0.0",
+    "ovos-spec-tools>=0.11.0a1,<1.0.0",
     "ovos-utils>=0.3.5,<1.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,10 @@ extras = [
     "ovos-plugin-manager>=0.5.0,<3.0.0",
 ]
 test = [
-    "ovos-plugin-manager>=0.5.0,<3.0.0",
+    # ovos-bus-client>=2.4.0a1 is only satisfiable with opm 2.x (prerelease);
+    # the stable opm releases all cap ovos-bus-client<2.0.0. Pin the prerelease
+    # floor so the resolver picks it without --pre.
+    "ovos-plugin-manager>=2.3.0a1,<3.0.0",
     "ovos-utils>=0.3.5,<1.0.0",
     "ovos-bus-client>=2.4.0a1,<3.0.0",
 ]

--- a/test/end2end/test_intent4_consume_e2e.py
+++ b/test/end2end/test_intent4_consume_e2e.py
@@ -1,0 +1,172 @@
+"""OVOS-INTENT-4 *consumer* end-to-end tests for the Padacioso pipeline.
+
+``test/test_ovoscope_e2e.py`` proves padacioso matches intents registered via
+the legacy ``padatious:register_*`` events. This suite proves padacioso
+*consumes the INTENT-4 spec registration topics* (``ovos-intent-4.md``) and then
+matches.
+
+Padacioso is a **template** engine: it consumes ``ovos.intent.register.template``
+(§6) and not ``ovos.intent.register.keyword`` (§11). Each test boots a real
+``MiniCroft`` pinned to the padacioso pipeline, emits the spec registration on
+the wire, sends a matching utterance, and asserts the intent dispatches
+``<skill_id>:<intent_name>`` — proving spec-topic consumption.
+"""
+import time
+import unittest
+
+import pytest
+
+ovoscope = pytest.importorskip(
+    "ovoscope", reason="ovoscope not installed; skipping E2E tests"
+)
+
+from ovoscope import E2EPipelineHarness  # noqa: E402
+from ovos_bus_client.message import Message  # noqa: E402
+from ovos_spec_tools import SpecMessage  # noqa: E402
+
+from padacioso.opm import PadaciosoPipeline  # noqa: E402
+
+PIPELINE_ID = "ovos-padacioso-pipeline-plugin"
+CONFIG_KEY = "padacioso"
+
+REGISTER_TEMPLATE = str(SpecMessage.INTENT_REGISTER_TEMPLATE)
+REGISTER_KEYWORD = str(SpecMessage.INTENT_REGISTER_KEYWORD)
+ENTITY_REGISTER = str(SpecMessage.ENTITY_REGISTER)
+INTENT_DEREGISTER = str(SpecMessage.INTENT_DEREGISTER)
+SKILL_DEREGISTER = str(SpecMessage.SKILL_DEREGISTER)
+INTENT_DISABLE = str(SpecMessage.INTENT_DISABLE)
+INTENT_ENABLE = str(SpecMessage.INTENT_ENABLE)
+
+_HELLO = ["hello", "hi there", "hey"]
+_BYE = ["goodbye", "bye bye", "see you"]
+
+
+class _Intent4PadaciosoHarness(E2EPipelineHarness):
+    PIPELINE_ID = PIPELINE_ID
+    CONFIG_KEY = CONFIG_KEY
+    PLUGIN_CONFIG = {}
+    SKILL_ID = "intent4_padacioso.skill"
+
+    pipeline: PadaciosoPipeline  # type: ignore[assignment]
+
+    def _register_template(self, intent_name, samples, *, blacklist=None,
+                           lang="en-US", settle=1.0):
+        payload = {
+            "skill_id": self.SKILL_ID,
+            "intent_name": intent_name,
+            "lang": lang,
+            "samples": samples,
+        }
+        if blacklist is not None:
+            payload["blacklist"] = blacklist
+        self.bus.emit(Message(REGISTER_TEMPLATE, payload,
+                              {"skill_id": self.SKILL_ID}))
+        time.sleep(settle)
+
+    def _capture_match(self, utterance, intent_name, timeout=5.0):
+        """send_and_capture with one retry — the first match after a fresh
+        MiniCroft boot occasionally races the pipeline-ready state."""
+        expected = [f"{self.SKILL_ID}:{intent_name}"]
+        msg = self.send_and_capture(utterance, expected_types=expected,
+                                    timeout=timeout)
+        if msg is None:
+            time.sleep(0.5)
+            msg = self.send_and_capture(utterance, expected_types=expected,
+                                        timeout=timeout)
+        return msg
+
+    def _emit(self, topic, intent_name=None, settle=0.8, **extra):
+        data = {"skill_id": self.SKILL_ID, "lang": "en-US"}
+        if intent_name is not None:
+            data["intent_name"] = intent_name
+        data.update(extra)
+        self.bus.emit(Message(topic, data, {"skill_id": self.SKILL_ID}))
+        time.sleep(settle)
+
+
+class TestSpecTemplateConsumed(_Intent4PadaciosoHarness):
+    """§6: a template intent registered on the spec topic becomes matchable."""
+
+    def test_spec_template_registration_is_matchable(self):
+        self._register_template("hello", _HELLO)
+        msg = self._capture_match("hello", "hello")
+        self.assertIsNotNone(msg, "expected intent match from spec registration")
+        self.assertEqual(msg.msg_type, f"{self.SKILL_ID}:hello")
+
+    def test_spec_template_slot_capture(self):
+        """A ``{slot}`` template fills from the utterance (§6.1)."""
+        self._register_template("buy", ["buy {item}", "purchase {item}"])
+        msg = self._capture_match("buy milk", "buy")
+        self.assertIsNotNone(msg, "slot template should match")
+
+
+class TestLegacyStillConsumed(_Intent4PadaciosoHarness):
+    """Back-compat: legacy ``padatious:register_intent`` still matches."""
+
+    def test_legacy_template_registration_still_matches(self):
+        from ovoscope import register_padatious_intent
+        register_padatious_intent(self.bus, f"{self.SKILL_ID}:bye", _BYE)
+        time.sleep(0.4)
+        msg = self.send_and_capture(
+            "goodbye", expected_types=[f"{self.SKILL_ID}:bye"]
+        )
+        self.assertIsNotNone(msg, "legacy registration must still match")
+
+
+class TestSpecDeregister(_Intent4PadaciosoHarness):
+    """§8.2 / §8.4: spec deregistration removes a spec-registered intent."""
+
+    def test_spec_deregister_removes_intent(self):
+        self._register_template("hello", _HELLO)
+        self.assertIsNotNone(
+            self._capture_match("hello", "hello"),
+            "sanity: intent should match before deregister",
+        )
+        self._emit(INTENT_DEREGISTER, "hello")
+        self.expect_no_match("hello", timeout=3.0)
+
+    def test_spec_skill_deregister_removes_intent(self):
+        self._register_template("hello", _HELLO)
+        self._emit(SKILL_DEREGISTER)
+        self.expect_no_match("hello", timeout=3.0)
+
+
+class TestSpecDisableEnable(_Intent4PadaciosoHarness):
+    """§8.5: ``ovos.intent.disable`` suppresses, ``ovos.intent.enable`` re-arms.
+
+    Padacioso has no native suppression flag, so disable removes the intent's
+    regexes from the container while retaining the expanded samples for
+    re-arming — registration-scoped suppression per §8.5.
+    """
+
+    def test_spec_disable_suppresses_intent(self):
+        self._register_template("hello", _HELLO)
+        self._emit(INTENT_DISABLE, "hello")
+        self.expect_no_match("hello", timeout=3.0)
+
+    def test_spec_enable_rearms_intent(self):
+        self._register_template("hello", _HELLO)
+        self._emit(INTENT_DISABLE, "hello")
+        self._emit(INTENT_ENABLE, "hello")
+        msg = self._capture_match("hello", "hello")
+        self.assertIsNotNone(msg, "intent should match again after enable")
+
+
+class TestNegativeKeywordTopic(_Intent4PadaciosoHarness):
+    """§11: a template engine MUST NOT consume the *keyword* topic."""
+
+    def test_keyword_topic_does_not_match_on_template_engine(self):
+        self.bus.emit(Message(REGISTER_KEYWORD, {
+            "skill_id": self.SKILL_ID,
+            "intent_name": "lights_off",
+            "lang": "en-US",
+            "required": [{"name": "TurnOff", "samples": ["off"]},
+                         {"name": "Light", "samples": ["lights"]}],
+            "optional": [], "one_of": [], "excluded": [],
+        }, {"skill_id": self.SKILL_ID}))
+        time.sleep(0.5)
+        self.expect_no_match("turn off the lights", timeout=3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -64,3 +64,128 @@ class UtteranceIntentMatchingTest(unittest.TestCase):
         self.assertEqual(intent.matches, {'thing': 'mycroft'})
         self.assertEqual(intent.sent, utterance)
         self.assertTrue(intent.conf <= 0.8)
+
+
+class Intent4RegistrationTest(unittest.TestCase):
+    """OVOS-INTENT-4 template registration consumed alongside legacy topics."""
+
+    def get_service(self):
+        from ovos_spec_tools import SpecMessage
+        self.SpecMessage = SpecMessage
+        return PadaciosoPipeline(FakeBus(), {"fuzz": False})
+
+    def test_register_template_and_match(self):
+        svc = self.get_service()
+        # register a template intent via ovos.intent.register.template (§6)
+        msg = Message(self.SpecMessage.INTENT_REGISTER_TEMPLATE.value, {
+            "skill_id": "music.skill",
+            "intent_name": "play_music",
+            "lang": "en-US",
+            "samples": ["play {query}", "i want to listen to {query}"],
+        })
+        svc.handle_register_template(msg)
+
+        # internal name is namespaced <skill_id>:<intent_name>
+        self.assertIn("music.skill:play_music",
+                      svc.containers["en-US"].intent_samples)
+
+        # an utterance matches and the slot is captured
+        intent = svc.calc_intent("play the beatles", "en-US")
+        self.assertEqual(intent.name, "music.skill:play_music")
+        self.assertEqual(intent.matches, {"query": "the beatles"})
+
+    def test_blacklist_suppresses_match(self):
+        svc = self.get_service()
+        svc.handle_register_template(Message(
+            self.SpecMessage.INTENT_REGISTER_TEMPLATE.value, {
+                "skill_id": "music.skill", "intent_name": "play_music",
+                "lang": "en-US", "samples": ["play {query}"],
+                "blacklist": ["trailer"],
+            }))
+        # blacklisted phrase suppresses the match (§6.1)
+        intent = svc.calc_intent("play the trailer", "en-US")
+        self.assertIsNone(intent)
+        # non-blacklisted utterance still matches
+        intent = svc.calc_intent("play jazz", "en-US")
+        self.assertEqual(intent.name, "music.skill:play_music")
+
+    def test_entity_registration(self):
+        svc = self.get_service()
+        svc.handle_register_template(Message(
+            self.SpecMessage.INTENT_REGISTER_TEMPLATE.value, {
+                "skill_id": "music.skill", "intent_name": "play_on",
+                "lang": "en-US", "samples": ["play {query} on {engine}"],
+            }))
+        svc.handle_register_entity(Message(
+            self.SpecMessage.ENTITY_REGISTER.value, {
+                "skill_id": "music.skill", "entity_name": "engine",
+                "lang": "en-US", "samples": ["spotify", "youtube"],
+            }))
+        self.assertIn("music.skill:engine",
+                      svc.containers["en-US"].entity_samples)
+
+    def test_deregister_intent(self):
+        svc = self.get_service()
+        svc.handle_register_template(Message(
+            self.SpecMessage.INTENT_REGISTER_TEMPLATE.value, {
+                "skill_id": "music.skill", "intent_name": "play_music",
+                "lang": "en-US", "samples": ["play {query}"],
+            }))
+        svc.handle_deregister_intent(Message(
+            self.SpecMessage.INTENT_DEREGISTER.value, {
+                "skill_id": "music.skill", "intent_name": "play_music",
+                "lang": "en-US"}))
+        self.assertNotIn("music.skill:play_music",
+                         svc.containers["en-US"].intent_samples)
+        self.assertIsNone(svc.calc_intent("play jazz", "en-US"))
+
+    def test_deregister_skill(self):
+        svc = self.get_service()
+        for n in ("play_music", "stop_music"):
+            svc.handle_register_template(Message(
+                self.SpecMessage.INTENT_REGISTER_TEMPLATE.value, {
+                    "skill_id": "music.skill", "intent_name": n,
+                    "lang": "en-US", "samples": [f"{n} {{query}}"],
+                }))
+        svc.handle_deregister_skill(Message(
+            self.SpecMessage.SKILL_DEREGISTER.value, {"skill_id": "music.skill"}))
+        self.assertEqual(svc.containers["en-US"].intent_samples, {})
+
+    def test_disable_then_enable(self):
+        svc = self.get_service()
+        reg = lambda: svc.handle_register_template(Message(
+            self.SpecMessage.INTENT_REGISTER_TEMPLATE.value, {
+                "skill_id": "music.skill", "intent_name": "play_music",
+                "lang": "en-US", "samples": ["play {query}"],
+            }))
+        reg()
+        # disable removes it from matching but keeps the definition (§8.5).
+        # assert at the container level to avoid the engine's per-utterance
+        # lru_cache (keyed on container+session identity) masking re-arming.
+        svc.handle_disable_intent(Message(
+            self.SpecMessage.INTENT_DISABLE.value, {
+                "skill_id": "music.skill", "intent_name": "play_music",
+                "lang": "en-US"}))
+        self.assertNotIn("music.skill:play_music",
+                         svc.containers["en-US"].intent_samples)
+        # definition retained for re-arming
+        self.assertIn(("en-US", "music.skill:play_music"),
+                      svc._template_samples)
+        # enable re-arms it
+        svc.handle_enable_intent(Message(
+            self.SpecMessage.INTENT_ENABLE.value, {
+                "skill_id": "music.skill", "intent_name": "play_music",
+                "lang": "en-US"}))
+        self.assertIn("music.skill:play_music",
+                      svc.containers["en-US"].intent_samples)
+        intent = svc.calc_intent("play jazz", "en-US")
+        self.assertEqual(intent.name, "music.skill:play_music")
+
+    def test_legacy_still_works(self):
+        # back-compat: legacy padatious:register_intent path unchanged
+        svc = self.get_service()
+        svc.register_intent(Message("padatious:register_intent", {
+            "samples": ["hello there"], "lang": "en-US",
+            "name": "greet.skill:hello"}))
+        intent = svc.calc_intent("hello there", "en-US")
+        self.assertEqual(intent.name, "greet.skill:hello")


### PR DESCRIPTION
Migrates `PadaciosoPipeline` (the OPM pipeline plugin / bus layer) to consume the **OVOS-INTENT-4** registration bus topics **in addition to** the legacy `padatious:*` topics it already handled.

padacioso is a **TEMPLATE** intent engine, so per spec §11 it subscribes to `ovos.intent.register.template` and **ignores** `ovos.intent.register.keyword`.

## Topics consumed (new)
| Topic (`SpecMessage`) | § | Engine call |
|---|---|---|
| `ovos.intent.register.template` | §6 | `add_intent` (+ `exclude_keywords` for `blacklist`) |
| `ovos.entity.register` | §7 | `add_entity` |
| `ovos.intent.deregister` | §8.2 | `remove_intent` (all langs if `lang` omitted) |
| `ovos.entity.deregister` | §8.3 | `remove_entity` |
| `ovos.skill.deregister` | §8.4 | remove all intents+entities for `skill_id` |
| `ovos.intent.enable` / `ovos.intent.disable` | §8.5 | re-add / remove regexes, retaining the definition |

## Spec → engine mapping
- Spec carries `skill_id` + `intent_name` as distinct fields (§3.2); the engine stores intents under the namespaced `<skill_id>:<intent_name>` form (match-result skill_id is derived by splitting on `:`), so handlers recompose that internally.
- §8.1 implicit replacement: re-registration detaches the prior entry first.
- §6.1 `blacklist` → container keyword exclusion.
- §8.5 disable removes the regexes from matching but retains the expanded samples (`_template_samples`) so enable re-arms without re-broadcast.
- Malformed payloads (missing `samples`/identity) are dropped with a WARN log (§5.3/§6.3/§7.2).

Legacy `padatious:register_intent` / `register_entity` / `detach_intent` / `detach_skill` handlers are **untouched** (back-compat).

## Deps
- `ovos-spec-tools` floor bumped to `>=0.10.0a1` (provides `SpecMessage`).

## Tests
New `Intent4RegistrationTest` in `test/test_pipeline.py`: template register+match (slot captured), blacklist suppression, entity registration, deregister intent, deregister skill, disable→enable round-trip, and a legacy-still-works guard. Full suite: **48 passed** (pure-python, no native deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)