### PR TITLE
fix: drop unhashable Session from lru_cache key (ovos-bus-client 2.x compat)

### DIFF
--- a/padacioso/opm.py
+++ b/padacioso/opm.py
@@ -147,6 +147,8 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
             self.registered_intents.remove(intent_name)
             for lang in self.containers:
                 self.containers[lang].remove_intent(intent_name)
+            # the container was mutated; drop stale cached matches
+            _calc_padacioso_intent.cache_clear()
 
     def handle_detach_intent(self, message):
         """Messagebus handler for detaching padacioso intent.
@@ -165,6 +167,8 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
         """
         if lang in self.containers:
             self.containers[lang].remove_entity(name)
+            # the container was mutated; drop stale cached matches
+            _calc_padacioso_intent.cache_clear()
 
     def handle_detach_skill(self, message):
         """Messagebus handler for detaching all intents for skill.
@@ -204,6 +208,8 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
                 samples = [line.strip() for line in f.readlines()]
 
         register_func(name, samples)
+        # the container was mutated; drop stale cached matches
+        _calc_padacioso_intent.cache_clear()
 
     def register_intent(self, message):
         """Messagebus handler for registering intents.

--- a/padacioso/opm.py
+++ b/padacioso/opm.py
@@ -261,9 +261,14 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
             return None
 
         sess = SessionManager.get(message)
+        # Session is not hashable, so it cannot be an lru_cache key. Pass the
+        # blacklists it carries as frozensets (hashable) instead.
+        blacklisted_intents = frozenset(sess.blacklisted_intents or [])
+        blacklisted_skills = frozenset(sess.blacklisted_skills or [])
 
         intent_container = self.containers.get(lang)
-        intents = [_calc_padacioso_intent(utt, intent_container, sess)
+        intents = [_calc_padacioso_intent(utt, intent_container,
+                                          blacklisted_intents, blacklisted_skills)
                    for utt in utterances]
         intents = [i for i in intents if i is not None]
         # select best
@@ -285,7 +290,8 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
 @lru_cache(maxsize=128)  # covers burst of multiple ASR hypotheses without thrashing
 def _calc_padacioso_intent(utt: str,
                            intent_container: FallbackIntentContainer,
-                           sess: Session) -> \
+                           blacklisted_intents: frozenset = frozenset(),
+                           blacklisted_skills: frozenset = frozenset()) -> \
         Optional[PadaciosoIntent]:
     """
     Try to match an utterance to an intent in an intent_container
@@ -295,8 +301,8 @@ def _calc_padacioso_intent(utt: str,
     try:
         intents = [i for i in intent_container.calc_intents(utt)
                    if i is not None
-                   and i["name"] not in sess.blacklisted_intents
-                   and i["name"].split(":")[0] not in sess.blacklisted_skills]
+                   and i["name"] not in blacklisted_intents
+                   and i["name"].split(":")[0] not in blacklisted_skills]
         if len(intents) == 0:
             return None
         best_conf = max(x.get("conf", 0) for x in intents if x.get("name"))


### PR DESCRIPTION
ovos-bus-client 2.x makes `Session` unhashable (`Session.__hash__ is None`), so passing it as an `@lru_cache` argument to `_calc_padacioso_intent` raised `TypeError: unhashable type: 'Session'` on **every** match attempt — padacioso silently matched nothing under bus-client 2.x.

Fix: pass the two blacklist sets the matcher actually reads as `frozenset`s (hashable) instead of the whole Session. Restores caching + matching under bus-client 2.x.

Found by live integration testing in the OVOS spec-compliance harness (the Session change ships in ovos-bus-client#234). Also handles `blacklisted_*` being `None` (optional SESSION-1 field) via `or []`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)