### PR TITLE
fix: re-arm legacy-registered intents on ovos.intent.enable (§8.5)

### DIFF
--- a/padacioso/opm.py
+++ b/padacioso/opm.py
@@ -91,8 +91,14 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
         self.registered_entities = []
         # OVOS-INTENT-4 §8.5 enable/disable: keep the expanded template samples
         # keyed by (lang, internal_name) so a disabled intent can be re-armed
-        # without losing its definition.
+        # without losing its definition. Populated by the spec template path.
         self._template_samples = {}
+        # A disable can target an intent registered via *either* the spec
+        # template path or the legacy ``padatious:register_intent`` path (which
+        # does not fill ``_template_samples``). Stash the live samples pulled
+        # from the container at disable time, keyed by (lang, internal_name), so
+        # enable can re-arm regardless of how the intent was registered.
+        self._disabled_intents = {}
         self.max_words = 50  # if an utterance contains more words than this, don't attempt to match
         LOG.debug('Loaded Padacioso intent parser.')
 
@@ -412,7 +418,11 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
         intent_name = message.data.get("intent_name")
         name = self._internal_name(skill_id, intent_name)
         for lang in self._intent_langs(message):
-            if name in self.containers[lang].intent_samples:
+            samples = self.containers[lang].intent_samples.get(name)
+            if samples is not None:
+                # retain the live samples so a legacy-registered intent (which
+                # never populated ``_template_samples``) can still be re-armed
+                self._disabled_intents[(lang, name)] = list(samples)
                 self.containers[lang].remove_intent(name)
 
     def handle_enable_intent(self, message: Message):
@@ -422,8 +432,13 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
         name = self._internal_name(skill_id, intent_name)
         for lang in self._intent_langs(message):
             if name in self.containers[lang].intent_samples:
+                self._disabled_intents.pop((lang, name), None)
                 continue  # already enabled, no-op
-            samples = self._template_samples.get((lang, name))
+            # prefer the samples stashed at disable time (works for both the
+            # spec and legacy registration paths); fall back to the retained
+            # template definition for a spec-registered intent.
+            samples = (self._disabled_intents.pop((lang, name), None)
+                       or self._template_samples.get((lang, name)))
             if samples:
                 self.containers[lang].add_intent(name, samples)
 

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -181,6 +181,33 @@ class Intent4RegistrationTest(unittest.TestCase):
         intent = svc.calc_intent("play jazz", "en-US")
         self.assertEqual(intent.name, "music.skill:play_music")
 
+    def test_disable_then_enable_legacy_registered(self):
+        # §8.5 must re-arm an intent registered via the *legacy*
+        # ``padatious:register_intent`` path too — that path never populates
+        # ``_template_samples``, so enable relies on the samples stashed at
+        # disable time. Regression for a disabled legacy intent that could
+        # never be re-enabled (stayed unmatched forever).
+        svc = self.get_service()
+        svc.register_intent(Message("padatious:register_intent", {
+            "samples": ["play {query}"], "lang": "en-US",
+            "name": "music.skill:play_music"}))
+        self.assertEqual(svc.calc_intent("play jazz", "en-US").name,
+                         "music.skill:play_music")
+        svc.handle_disable_intent(Message(
+            self.SpecMessage.INTENT_DISABLE.value, {
+                "skill_id": "music.skill", "intent_name": "play_music",
+                "lang": "en-US"}))
+        self.assertNotIn("music.skill:play_music",
+                         svc.containers["en-US"].intent_samples)
+        svc.handle_enable_intent(Message(
+            self.SpecMessage.INTENT_ENABLE.value, {
+                "skill_id": "music.skill", "intent_name": "play_music",
+                "lang": "en-US"}))
+        self.assertIn("music.skill:play_music",
+                      svc.containers["en-US"].intent_samples)
+        self.assertEqual(svc.calc_intent("play jazz", "en-US").name,
+                         "music.skill:play_music")
+
     def test_legacy_still_works(self):
         # back-compat: legacy padatious:register_intent path unchanged
         svc = self.get_service()


### PR DESCRIPTION
## Problem

`ovos.intent.disable` removes an intent from the padacioso container but discards
its samples. `ovos.intent.enable` restores them **only** from `_template_samples`,
which is populated exclusively by the spec template-registration path
(`handle_register_template`). An intent registered via the legacy
`padatious:register_intent` topic — what real skills and ovoscope's
`register_padatious_intent` use — never populates `_template_samples`, so once
disabled it could **never** be re-enabled: it stayed `unmatched` forever,
contradicting OVOS-INTENT-4 §8.5.

This is the single hard failure reddening `ovos-test-harness` dev
(`test_intent4_conformance.py::TestSec85Enable::test_spec_enable_rearms_intent`).

## Fix

Stash the live container samples at **disable** time, keyed by
`(lang, internal_name)`, and restore from that stash on **enable** (falling back
to `_template_samples` for spec-registered intents). Re-arming now works
regardless of registration path — fully backward compatible with both the legacy
and spec topics.

## Tests

Adds `test_disable_then_enable_legacy_registered` covering the
legacy-registered disable→enable→match cycle. Verified it fails on `dev` and
passes with this fix; the full `test_pipeline.py` suite stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intent disable/enable behavior so disabled intents can be restored reliably, including intents added through older registration flows.
  * Re-enabling now brings back the previous active intent samples, preventing intents from losing their match behavior after being toggled off.

* **Tests**
  * Added coverage for disabling and re-enabling a legacy-registered intent to confirm it matches again after restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->