### PR TITLE
feat: enforce OVOS-CONTEXT-1 requires_context/excludes_context gating

### DIFF
--- a/padacioso/opm.py
+++ b/padacioso/opm.py
@@ -9,7 +9,7 @@ from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager, Session
 from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
-from ovos_spec_tools import closest_lang, standardize_lang, SpecMessage
+from ovos_spec_tools import closest_lang, standardize_lang, SpecMessage, gate_satisfied
 from ovos_utils import flatten_list
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG, log_deprecation
@@ -99,8 +99,27 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
         # from the container at disable time, keyed by (lang, internal_name), so
         # enable can re-arm regardless of how the intent was registered.
         self._disabled_intents = {}
+        # OVOS-CONTEXT-1 §6/§6.1 — optional requires_context/excludes_context
+        # gating declarations, keyed by internal intent name. Independent of
+        # lang and of the enable/disable/detach match state: retained until the
+        # intent is deregistered/detached so a re-armed intent keeps its gate.
+        self._intent_context_gates = {}
         self.max_words = 50  # if an utterance contains more words than this, don't attempt to match
         LOG.debug('Loaded Padacioso intent parser.')
+
+    def _store_context_gate(self, name: str, data: Dict):
+        """OVOS-CONTEXT-1 §6 — retain optional context gates for an intent.
+
+        ``requires_context`` / ``excludes_context`` are each an optional list
+        of bare-string keys or ``{"key","scope"}`` mappings (default private).
+        Absent/empty declarations clear any prior gate for the name.
+        """
+        requires = data.get("requires_context")
+        excludes = data.get("excludes_context")
+        if requires or excludes:
+            self._intent_context_gates[name] = (requires, excludes)
+        else:
+            self._intent_context_gates.pop(name, None)
 
     @staticmethod
     def _internal_name(skill_id: str, intent_name: str) -> str:
@@ -181,6 +200,7 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
         """
         if intent_name in self.registered_intents:
             self.registered_intents.remove(intent_name)
+            self._intent_context_gates.pop(intent_name, None)
             for lang in self.containers:
                 self.containers[lang].remove_intent(intent_name)
             # the container was mutated; drop stale cached matches
@@ -257,6 +277,7 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
         lang = standardize_lang(lang)
         if lang in self.containers:
             self.registered_intents.append(message.data['name'])
+            self._store_context_gate(message.data['name'], message.data)
             try:
                 self._register_object(message, 'intent',
                                       self.containers[lang].add_intent)
@@ -322,6 +343,7 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
         self.__detach_intent(name)
         self.registered_intents.append(name)
         self._template_samples[(lang, name)] = list(samples)
+        self._store_context_gate(name, data)
         try:
             self.containers[lang].add_intent(name, samples)
         except RuntimeError:
@@ -482,6 +504,24 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
                                           blacklisted_intents, blacklisted_skills)
                    for utt in utterances]
         intents = [i for i in intents if i is not None]
+        # OVOS-CONTEXT-1 §6/§6.1 — drop candidates whose requires_context /
+        # excludes_context gate is not satisfied by the live session context.
+        # gate_satisfied handles §2 liveness, §3.1 scope and §4 decay.
+        if self._intent_context_gates:
+            ctx = sess.intent_context or {}
+            gated = []
+            for i in intents:
+                gate = self._intent_context_gates.get(i.name)
+                if gate is None:
+                    gated.append(i)
+                    continue
+                requires, excludes = gate
+                owner_id = i.name.split(":")[0]
+                if gate_satisfied(ctx, requires, excludes, owner_id=owner_id):
+                    gated.append(i)
+                else:
+                    LOG.debug(f"context gate rejected intent: {i.name}")
+            intents = gated
         # select best
         if intents:
             return max(intents, key=lambda k: k.conf)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "jarbasai", email = "jarbasai@mailfence.com" }]
 requires-python = ">=3.8"
 dependencies = [
     "simplematch",
-    "ovos-spec-tools>=0.16.1a2",
+    "ovos-spec-tools>=1.4.0a1",
     "ovos-utils>=0.3.5,<1.0.0",
 ]
 

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -216,3 +216,104 @@ class Intent4RegistrationTest(unittest.TestCase):
             "name": "greet.skill:hello"}))
         intent = svc.calc_intent("hello there", "en-US")
         self.assertEqual(intent.name, "greet.skill:hello")
+
+
+class ContextGatingTest(unittest.TestCase):
+    """OVOS-CONTEXT-1 §6/§6.1 requires_context / excludes_context gating."""
+
+    def get_service(self):
+        from ovos_spec_tools import SpecMessage
+        self.SpecMessage = SpecMessage
+        return PadaciosoPipeline(FakeBus(), {"fuzz": False})
+
+    def _msg_with_context(self, intent_context):
+        from ovos_bus_client.session import Session
+        sess = Session("test-session")
+        sess.intent_context = intent_context
+        return Message("recognizer_loop:utterance", {},
+                       {"session": sess.serialize()})
+
+    def test_requires_context_present_vs_absent(self):
+        svc = self.get_service()
+        # register an intent gated on a private context key
+        svc.handle_register_template(Message(
+            self.SpecMessage.INTENT_REGISTER_TEMPLATE.value, {
+                "skill_id": "tv.skill",
+                "intent_name": "turn_off",
+                "lang": "en-US",
+                "samples": ["turn off the tv"],
+                "requires_context": ["tv_on"],
+            }))
+        self.assertIn(("tv.skill:turn_off"),
+                      svc._intent_context_gates)
+
+        # context absent -> gate fails -> no match
+        msg = self._msg_with_context({})
+        self.assertIsNone(svc.calc_intent("turn off the tv", "en-US", msg))
+
+        # private key stored as <owner_id>:<key> -> gate satisfied -> match
+        msg = self._msg_with_context({"tv.skill:tv_on": {"value": True}})
+        intent = svc.calc_intent("turn off the tv", "en-US", msg)
+        self.assertEqual(intent.name, "tv.skill:turn_off")
+
+    def test_excludes_context_drops_match(self):
+        svc = self.get_service()
+        svc.handle_register_template(Message(
+            self.SpecMessage.INTENT_REGISTER_TEMPLATE.value, {
+                "skill_id": "media.skill",
+                "intent_name": "play",
+                "lang": "en-US",
+                "samples": ["play something"],
+                "excludes_context": ["playing"],
+            }))
+        # exclude key absent -> match allowed
+        msg = self._msg_with_context({})
+        self.assertEqual(
+            svc.calc_intent("play something", "en-US", msg).name,
+            "media.skill:play")
+        # exclude key present (live) -> match dropped
+        msg = self._msg_with_context({"media.skill:playing": {"value": True}})
+        self.assertIsNone(svc.calc_intent("play something", "en-US", msg))
+
+    def test_ungated_intent_unaffected(self):
+        svc = self.get_service()
+        svc.handle_register_template(Message(
+            self.SpecMessage.INTENT_REGISTER_TEMPLATE.value, {
+                "skill_id": "greet.skill",
+                "intent_name": "hi",
+                "lang": "en-US",
+                "samples": ["hello there"],
+            }))
+        self.assertNotIn("greet.skill:hi", svc._intent_context_gates)
+        msg = self._msg_with_context({})
+        self.assertEqual(
+            svc.calc_intent("hello there", "en-US", msg).name,
+            "greet.skill:hi")
+
+    def test_legacy_register_stores_gate(self):
+        svc = self.get_service()
+        svc.register_intent(Message("padatious:register_intent", {
+            "samples": ["lock the door"], "lang": "en-US",
+            "name": "home.skill:lock", "requires_context": ["armed"]}))
+        self.assertIn("home.skill:lock", svc._intent_context_gates)
+        self.assertIsNone(svc.calc_intent("lock the door", "en-US",
+                                          self._msg_with_context({})))
+        msg = self._msg_with_context({"home.skill:armed": {"value": True}})
+        self.assertEqual(svc.calc_intent("lock the door", "en-US", msg).name,
+                         "home.skill:lock")
+
+    def test_gate_dropped_on_deregister(self):
+        svc = self.get_service()
+        svc.handle_register_template(Message(
+            self.SpecMessage.INTENT_REGISTER_TEMPLATE.value, {
+                "skill_id": "tv.skill", "intent_name": "off",
+                "lang": "en-US", "samples": ["off"],
+                "requires_context": ["tv_on"]}))
+        svc.handle_deregister_intent(Message(
+            self.SpecMessage.INTENT_DEREGISTER.value, {
+                "skill_id": "tv.skill", "intent_name": "off"}))
+        self.assertNotIn("tv.skill:off", svc._intent_context_gates)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Enforces OVOS-CONTEXT-1 §6/§6.1 context gating in the padacioso pipeline.

## What
- **Storage**: optional `requires_context` / `excludes_context` (each a list of bare-string keys or `{"key","scope"}` mappings, default private) are stored per registered intent in `self._intent_context_gates`, keyed by internal `<skill_id>:<intent_name>` name. Populated from both the OVOS-INTENT-4 template path (`ovos.intent.register.template`) and the legacy `padatious:register_intent` path. Independent of lang and of the enable/disable match state (mirrors the `_disabled_intents` retention style), so a re-armed intent keeps its gate; dropped on detach/deregister.
- **Enforcement**: in `calc_intent`, after candidates are collected, each gated candidate is dropped unless `gate_satisfied(session.intent_context or {}, requires, excludes, owner_id=skill_id)` is True. Liveness/scope/decay are delegated to `ovos_spec_tools.gate_satisfied` (module `ovos_spec_tools.context`), not reimplemented.

Additive and back-compat: ungated intents are untouched.

## Dependency
Raises `ovos-spec-tools` floor to `>=1.4.0a1` (next expected published alpha carrying `gate_satisfied`; the helper currently lives on unpublished branch `feat/context-1-gating-helpers`, version 1.2.2a1). **Merge blocked on that spec-tools release.**

## Tests
Added `ContextGatingTest` to `test/test_pipeline.py`: requires_context present-vs-absent, excludes_context drop, ungated-unaffected, legacy-path gate storage, gate-dropped-on-deregister. Full suite (15 tests) passes in a fresh uv venv with the spec-tools branch installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)