### PR TITLE
fix: ack mycroft.skills.train with mycroft.skills.trained

### DIFF
--- a/padacioso/opm.py
+++ b/padacioso/opm.py
@@ -88,6 +88,12 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
         self.bus.on(SpecMessage.INTENT_ENABLE.value, self.handle_enable_intent)
         self.bus.on(SpecMessage.INTENT_DISABLE.value, self.handle_disable_intent)
 
+        # Registrations compile their regex synchronously as they arrive, so
+        # there is never a pending training step: ack train requests
+        # immediately so ovos-core does not wait for a reply that only
+        # engines with a real training step would otherwise send.
+        self.bus.on("mycroft.skills.train", self.handle_train)
+
         self.registered_intents = []
         self.registered_entities = []
         # OVOS-INTENT-4 §8.5 enable/disable: keep the expanded template samples
@@ -574,7 +580,21 @@ class PadaciosoPipeline(ConfidenceMatcherPipeline):
             return closest_lang(lang, list(self.containers.keys()))
         return None
 
+    def handle_train(self, message: Optional[Message] = None):
+        """Ack ``mycroft.skills.train`` with ``mycroft.skills.trained``.
+
+        Intent templates are compiled at registration time, so by the time a
+        train request is observed there is nothing left to train and the ack
+        can be sent right away. Without this reply ovos-core would wait out
+        its full training timeout whenever no engine with a real training
+        step is installed.
+        """
+        reply = (message.forward("mycroft.skills.trained")
+                 if message else Message("mycroft.skills.trained"))
+        self.bus.emit(reply)
+
     def shutdown(self):
+        self.bus.remove("mycroft.skills.train", self.handle_train)
         self.bus.remove('padatious:register_intent', self.register_intent)
         self.bus.remove('padatious:register_entity', self.register_entity)
         self.bus.remove('detach_intent', self.handle_detach_intent)

--- a/test/test_train_ack.py
+++ b/test/test_train_ack.py
@@ -1,0 +1,44 @@
+"""Regression tests for the ``mycroft.skills.train`` acknowledgement.
+
+ovos-core requests pipeline training at boot with
+``wait_for_response(Message("mycroft.skills.train"), "mycroft.skills.trained")``.
+Padacioso compiles intents at registration time, so it must answer
+immediately; otherwise installs without an engine that has a real training
+step wait out the full training timeout and log a misleading error.
+"""
+
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+
+from padacioso.opm import PadaciosoPipeline
+
+
+class TestTrainAck(unittest.TestCase):
+    def setUp(self):
+        self.bus = FakeBus()
+        self.pipeline = PadaciosoPipeline(self.bus, {})
+        self.trained = []
+        self.bus.on("mycroft.skills.trained", self.trained.append)
+
+    def test_acks_train_request(self):
+        self.bus.emit(Message("mycroft.skills.train"))
+        self.assertEqual(len(self.trained), 1)
+        self.assertEqual(self.trained[0].msg_type, "mycroft.skills.trained")
+
+    def test_ack_preserves_message_context(self):
+        self.bus.emit(Message("mycroft.skills.train",
+                              context={"session": {"session_id": "abc"}}))
+        self.assertEqual(
+            self.trained[0].context.get("session", {}).get("session_id"),
+            "abc")
+
+    def test_no_ack_after_shutdown(self):
+        self.pipeline.shutdown()
+        self.bus.emit(Message("mycroft.skills.train"))
+        self.assertEqual(self.trained, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Answer `mycroft.skills.train` with `mycroft.skills.trained`. Padacioso compiles intent templates synchronously at registration time, so there is never a pending training step and the ack is immediate.

ovos-core requests training at boot with `wait_for_response(Message("mycroft.skills.train"), "mycroft.skills.trained", timeout=60)`; without this reply, installs where no engine has a real training step wait out the full 60 seconds and log "Intent training timed out" even though registration completed in seconds.

## Tests
`test/test_train_ack.py`: ack emitted on request, message context preserved, no ack after shutdown. Fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)